### PR TITLE
refactor: replace Svelte/SvelteKit with TanStack Start stack for tourvy project

### DIFF
--- a/src/content/work-en/2021-08-01-tourvy.md
+++ b/src/content/work-en/2021-08-01-tourvy.md
@@ -13,10 +13,12 @@ tasks:
   - "Unified Inbox & Team Collaboration: Central request management system with multi-source intake (email, form, WhatsApp, API), RFC 5322-compliant email threading implementation, Kanban board/list views, team-based assignment workflow, and role-based access control for scalable multi-tenant SaaS architecture"
   - "Content Management & Media Library: Reusable asset library for accommodations, images, and templates with AI-powered tagging (OpenAI Vision API), Unsplash integration, geographic filtering, and asynchronous background processing via Inngest – centralizes content management and accelerates trip creation"
   - "Subscription & Billing System: Flexible payment integration with multi-provider support (Stripe, Mollie), JSONB-based feature flag system for tiered pricing (Freemium to Enterprise), trial management, usage tracking, and automated lifecycle events for SaaS monetization"
-  - "Type-Safe Full-Stack Architecture: Remote Functions pattern (type-safe alternative to tRPC) with automatic reactivity, URL-based dialog service for shareable modals, Svelte 5 Runes migration (complete codebase), TypeScript Strict Mode (ZERO error tolerance), and dual migration strategy (Drizzle ORM + Supabase) for maintainable enterprise codebase"
+  - "Type-Safe Full-Stack Architecture: TanStack Start Server Functions (type-safe alternative to tRPC) with automatic reactivity, URL-based dialog service for shareable modals, TanStack Router with file-based routing, TypeScript Strict Mode (ZERO error tolerance), and dual migration strategy (Drizzle ORM + Supabase) for maintainable enterprise codebase"
 technologies:
-  - SvelteKit 2
-  - Svelte 5
+  - TanStack Start
+  - TanStack Router
+  - TanStack Query
+  - React
   - TypeScript
   - Drizzle ORM
   - PostgreSQL

--- a/src/content/work/2021-08-01-tourvy.md
+++ b/src/content/work/2021-08-01-tourvy.md
@@ -13,10 +13,12 @@ tasks:
   - "Unified Inbox & Team-Collaboration: Zentrales Request-Management-System mit Multi-Source-Intake (E-Mail, Form WhatsApp, API), RFC 5322-konformer E-Mail-Threading-Implementation, Kanban-Board/List-Views, Team-basierter Assignment-Workflow und rollenbasierter Zugriffskontrolle für skalierbare Multi-Tenant-SaaS-Architektur"
   - "Content-Management & Media-Library: Wiederverwendbare Asset-Bibliothek für Unterkünfte, Bilder und Templates mit AI-Powered-Tagging (OpenAI Vision API), Unsplash-Integration, geografischer Filterung und asynchroner Background-Verarbeitung via Inngest – zentralisiert Content-Verwaltung und beschleunigt Trip-Erstellung"
   - "Subscription & Billing-System: Flexible Payment-Integration mit Multi-Provider-Support (Stripe, Mollie), JSONB-basiertem Feature-Flag-System für tiered Pricing (Freemium bis Enterprise), Trial-Management, Usage-Tracking und automatisierten Lifecycle-Events für SaaS-Monetarisierung"
-  - "Type-Safe Full-Stack-Architektur: Remote Functions Pattern (Type-safe Alternative zu tRPC) mit automatischer Reaktivität, URL-basierter Dialog Service für shareable Modals, Svelte 5 Runes-Migration (komplette Codebasis), TypeScript Strict Mode (ZERO Fehler-Toleranz) und duale Migration-Strategie (Drizzle ORM + Supabase) für wartbare Enterprise-Codebasis"
+  - "Type-Safe Full-Stack-Architektur: TanStack Start Server Functions (Type-safe Alternative zu tRPC) mit automatischer Reaktivität, URL-basierter Dialog Service für shareable Modals, TanStack Router mit File-based Routing, TypeScript Strict Mode (ZERO Fehler-Toleranz) und duale Migration-Strategie (Drizzle ORM + Supabase) für wartbare Enterprise-Codebasis"
 technologies:
-  - SvelteKit 2
-  - Svelte 5
+  - TanStack Start
+  - TanStack Router
+  - TanStack Query
+  - React
   - TypeScript
   - Drizzle ORM
   - PostgreSQL


### PR DESCRIPTION
Update technology stack in both DE and EN versions to reflect migration
from SvelteKit 2/Svelte 5 to TanStack Start, Router, Query, and React.